### PR TITLE
Changed URL for repo ibiblio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         </repository>
         <repository>
             <id>ibiblio</id>
-            <url>http://mirrors.ibiblio.org/pub/mirrors/maven2</url>
+            <url>http://maven.ibiblio.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
The mirror URL was getting redirected and it was causing some jars to be corrupted which caused the buid to fail